### PR TITLE
Implement song page buttons

### DIFF
--- a/public/songs.html
+++ b/public/songs.html
@@ -1199,8 +1199,15 @@
                     <h1 class="hero-title">Choose your songs to enjoy your simchah</h1>
                     <p class="hero-subtitle">Explore lyrics and recordings that cover any kind of simchah,<br>from Bar Mitzvah to Sheva Brachos.</p>
                     <div class="hero-buttons">
-                        <button class="hero-button-primary">Download Pre-made Now</button>
-                        <button class="hero-button-secondary">Design your own</button>
+                        <button id="download-pre-made" class="hero-button-primary">Download Pre-made Now</button>
+                        <button id="design-own" class="hero-button-secondary">Design your own</button>
+                    </div>
+                    <div id="pre-made-select-container" style="display:none;margin-top:10px;">
+                        <select id="pre-made-select">
+                            <option value="" disabled selected>Select a sheet</option>
+                            <option value="niggun">Niggun Sheet</option>
+                            <option value="simcha">Simcha Sheet</option>
+                        </select>
                     </div>
                 </div>
             </section>
@@ -1648,6 +1655,33 @@
         
         // Initial render of sheet songs
         renderSheetSongs();
+
+        // Pre-made download selector logic
+        const preMadeButton = document.getElementById('download-pre-made');
+        const preMadeContainer = document.getElementById('pre-made-select-container');
+        const preMadeSelect = document.getElementById('pre-made-select');
+
+        preMadeButton.addEventListener('click', () => {
+            preMadeContainer.style.display = preMadeContainer.style.display === 'none' ? 'block' : 'none';
+        });
+
+        preMadeSelect.addEventListener('change', function () {
+            const value = this.value;
+            const links = {
+                niggun: 'https://drive.google.com/file/d/1X_aY7tb7E9RxKVyXDYkGAC_wMGznGJe6/view?usp=drive_link',
+                simcha: 'https://drive.google.com/file/d/1GrpBue_ukxtR7mKjuGZljXL_X-I7Y4wu/view?usp=drive_link'
+            };
+            if (links[value]) {
+                window.open(links[value], '_blank');
+                this.selectedIndex = 0;
+                preMadeContainer.style.display = 'none';
+            }
+        });
+
+        // Design your own button logic
+        document.getElementById('design-own').addEventListener('click', () => {
+            window.location.href = '/sheet-builder.html';
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- let users pick pre-made sheet link (niggun or simcha) directly from the songs page
- link "Design your own" on songs page to sheet builder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874fc5229b08331a55d8e2a9114d3b8